### PR TITLE
通信モジュールを分離

### DIFF
--- a/Classes/c2xa/communication/node.cpp
+++ b/Classes/c2xa/communication/node.cpp
@@ -1,0 +1,139 @@
+﻿
+/**
+
+    @file   node.cpp
+    @brief  node
+
+    @author 新ゝ月かりな(NewNotMoon)
+    @date   created on 2016/02/13
+
+*/
+
+#include <c2xa/exception.hpp>
+#include <c2xa/communication/node.hpp>
+
+using namespace c2xa;
+
+bool communication_node::init()
+{
+    using namespace cocos2d;
+    if( !Node::init() )
+    {
+        return false;
+    }
+    setName( "communication_node" );
+    scheduleUpdate();
+
+    listener_ = std::make_shared<bluetooth::listener>();
+    address_1p = 0;
+    address_2p = 0;
+
+    return true;
+}
+
+void communication_node::update( float )
+{
+    using namespace cocos2d;
+    if( listener_ )
+    {
+        auto accepted_ = listener_->accept();
+        if( accepted_ )
+        {
+            do
+            {
+                if( !connection_1p )
+                {
+                    if( address_1p == 0 )
+                    {
+                        // 初接続
+                        connection_1p = std::move( *accepted_ );
+                        address_1p = connection_1p->get_client_address();
+                        subject_1p.notify( connection_state::connect );
+                        break;
+                    }
+                    else if( address_1p == ( *accepted_ )->get_client_address() )
+                    {
+                        // 1p 再接続
+                        connection_1p = std::move( *accepted_ );
+                        subject_1p.notify( connection_state::reconnect );
+                        break;
+                    }
+                }
+                if( !connection_2p )
+                {
+                    if( address_2p == 0 )
+                    {
+                        // 初接続
+                        connection_2p = std::move( *accepted_ );
+                        address_2p = connection_2p->get_client_address();
+                        subject_2p.notify( connection_state::connect );
+                        break;
+                    }
+                    else if( address_2p == ( *accepted_ )->get_client_address() )
+                    {
+                        // 2p 再接続
+                        connection_2p = std::move( *accepted_ );
+                        subject_2p.notify( connection_state::reconnect );
+                        break;
+                    }
+                }
+            }
+            while( false );
+            if( connection_1p && connection_2p )
+            {
+                listener_.reset();
+            }
+        }
+    }
+
+    if( connection_1p )
+    {
+        auto receive = [ this ]()
+        {
+            std::memset( buffer_, '\0', sizeof( buffer_ ) );
+            return connection_1p->receive( buffer_, sizeof( buffer_ ), 0 );
+        };
+        try
+        {
+            auto state_ = receive();
+            while( state_ == bluetooth::connection::socket_state::success )
+            {
+                state_ = receive();
+            }
+        }
+        catch( bluetooth_disconnect_exception const& )
+        {
+            connection_1p.reset();
+            if( !listener_ )
+            {
+                listener_ = std::make_shared<bluetooth::listener>();
+            }
+            subject_1p.notify( connection_state::disconnect );
+        }
+    }
+    if( connection_2p )
+    {
+        auto receive = [ this ]
+        {
+            std::memset( buffer_, '\0', sizeof( buffer_ ) );
+            return connection_2p->receive( buffer_, sizeof( buffer_ ), 0 );
+        };
+        try
+        {
+            auto state_ = receive();
+            while( state_ == bluetooth::connection::socket_state::success )
+            {
+                state_ = receive();
+            }
+        }
+        catch( bluetooth_disconnect_exception const& )
+        {
+            connection_2p.reset();
+            if( !listener_ )
+            {
+                listener_ = std::make_shared<bluetooth::listener>();
+            }
+            subject_2p.notify( connection_state::disconnect );
+        }
+    }
+}

--- a/Classes/c2xa/communication/node.cpp
+++ b/Classes/c2xa/communication/node.cpp
@@ -9,7 +9,6 @@
 
 */
 
-#include <c2xa/exception.hpp>
 #include <c2xa/communication/node.hpp>
 
 using namespace c2xa;
@@ -83,57 +82,6 @@ void communication_node::update( float )
             {
                 listener_.reset();
             }
-        }
-    }
-
-    if( connection_1p )
-    {
-        auto receive = [ this ]()
-        {
-            std::memset( buffer_, '\0', sizeof( buffer_ ) );
-            return connection_1p->receive( buffer_, sizeof( buffer_ ), 0 );
-        };
-        try
-        {
-            auto state_ = receive();
-            while( state_ == bluetooth::connection::socket_state::success )
-            {
-                state_ = receive();
-            }
-        }
-        catch( bluetooth_disconnect_exception const& )
-        {
-            connection_1p.reset();
-            if( !listener_ )
-            {
-                listener_ = std::make_shared<bluetooth::listener>();
-            }
-            subject_1p.notify( connection_state::disconnect );
-        }
-    }
-    if( connection_2p )
-    {
-        auto receive = [ this ]
-        {
-            std::memset( buffer_, '\0', sizeof( buffer_ ) );
-            return connection_2p->receive( buffer_, sizeof( buffer_ ), 0 );
-        };
-        try
-        {
-            auto state_ = receive();
-            while( state_ == bluetooth::connection::socket_state::success )
-            {
-                state_ = receive();
-            }
-        }
-        catch( bluetooth_disconnect_exception const& )
-        {
-            connection_2p.reset();
-            if( !listener_ )
-            {
-                listener_ = std::make_shared<bluetooth::listener>();
-            }
-            subject_2p.notify( connection_state::disconnect );
         }
     }
 }

--- a/Classes/c2xa/communication/node.hpp
+++ b/Classes/c2xa/communication/node.hpp
@@ -1,0 +1,60 @@
+﻿
+/**
+
+    @file   node.hpp
+    @brief  node
+
+    @author 新ゝ月かりな(NewNotMoon)
+    @date   created on 2016/02/13
+
+*/
+#pragma once
+#ifndef C2XA_COMMUNICATION_NODE_HPP
+#define C2XA_COMMUNICATION_NODE_HPP
+
+#include <cocos2d.h>
+
+#include <c2xa/observer.hpp>
+#include <c2xa/communication/bluetooth/server.hpp>
+
+namespace c2xa
+{
+    enum class connection_state
+    {
+        wait,
+        connect,
+        disconnect,
+        reconnect,
+    };
+    class communication_node
+        : public cocos2d::Node
+    {
+    private:
+        using subject = subject<connection_state>;
+    private:
+        char buffer_[ 2048 ];
+        std::shared_ptr<bluetooth::listener> listener_;
+        std::shared_ptr<bluetooth::connection> connection_1p;
+        std::shared_ptr<bluetooth::connection> connection_2p;
+        BTH_ADDR address_1p;
+        BTH_ADDR address_2p;
+        subject subject_1p;
+        subject subject_2p;
+
+    public:
+        CREATE_FUNC( communication_node );
+        virtual bool init() override;
+        virtual void update( float ) override;
+        subject::interface_type *const get_subject_1p()
+        {
+            return &subject_1p;
+        }
+        subject::interface_type *const get_subject_2p()
+        {
+            return &subject_2p;
+        }
+    };
+    using com_node = communication_node;
+}
+
+#endif//C2XA_COMMUNICATION_NODE_HPP

--- a/Classes/c2xa/communication/node.hpp
+++ b/Classes/c2xa/communication/node.hpp
@@ -14,6 +14,7 @@
 
 #include <cocos2d.h>
 
+#include <c2xa/exception.hpp>
 #include <c2xa/observer.hpp>
 #include <c2xa/communication/bluetooth/server.hpp>
 
@@ -52,6 +53,64 @@ namespace c2xa
         subject::interface_type *const get_subject_2p()
         {
             return &subject_2p;
+        }
+        template< typename FUNC >
+        void receive_1p( FUNC func_ )
+        {
+            if( connection_1p )
+            {
+                try
+                {
+                    while( true )
+                    {
+                        std::memset( buffer_, '\0', sizeof( buffer_ ) );
+                        auto state_ = connection_1p->receive( buffer_, sizeof( buffer_ ), 0 );
+                        if( state_ != bluetooth::connection::socket_state::success )
+                        {
+                            break;
+                        }
+                        func_( buffer_ );
+                    }
+                }
+                catch( bluetooth_disconnect_exception const& )
+                {
+                    connection_1p.reset();
+                    if( !listener_ )
+                    {
+                        listener_ = std::make_shared<bluetooth::listener>();
+                    }
+                    subject_1p.notify( connection_state::disconnect );
+                }
+            }
+        }
+        template< typename FUNC >
+        void receive_2p( FUNC func_ )
+        {
+            if( connection_2p )
+            {
+                try
+                {
+                    while( true )
+                    {
+                        std::memset( buffer_, '\0', sizeof( buffer_ ) );
+                        auto state_ = connection_2p->receive( buffer_, sizeof( buffer_ ), 0 );
+                        if( state_ != bluetooth::connection::socket_state::success )
+                        {
+                            break;
+                        }
+                        func_( buffer_ );
+                    }
+                }
+                catch( bluetooth_disconnect_exception const& )
+                {
+                    connection_2p.reset();
+                    if( !listener_ )
+                    {
+                        listener_ = std::make_shared<bluetooth::listener>();
+                    }
+                    subject_2p.notify( connection_state::disconnect );
+                }
+            }
         }
     };
     using com_node = communication_node;

--- a/Classes/c2xa/exception.hpp
+++ b/Classes/c2xa/exception.hpp
@@ -8,16 +8,17 @@
 
 namespace c2xa
 {
+#ifdef _DEBUG
     struct error
     {
         std::string file;
-        decltype(__LINE__) line;
+        decltype( __LINE__ ) line;
         std::string function;
         std::string message;
-        
+
         error( error const& e )
             : file{ e.file }
-            , line{ e.line  }
+            , line{ e.line }
             , function{ e.function }
             , message{ e.message }
         {
@@ -31,7 +32,6 @@ namespace c2xa
         {
         }
     };
-
     struct exception
         : virtual std::exception
     {
@@ -42,7 +42,6 @@ namespace c2xa
         {
         }
     };
-
 #define _C2XA_EXCEPTION( name )\
     struct name##_exception\
         : public exception\
@@ -55,7 +54,18 @@ namespace c2xa
             : exception{ e }\
         {\
         }\
-    }
+    };
+#else
+    struct exception
+        : virtual std::exception
+    {
+    };
+#define _C2XA_EXCEPTION( name )\
+    struct name##_exception\
+        : public exception\
+    {\
+    };
+#endif
 
     _C2XA_EXCEPTION( bluetooth );
     _C2XA_EXCEPTION( bluetooth_disconnect );
@@ -65,7 +75,7 @@ namespace c2xa
 #ifdef _DEBUG
 #define C2XA_THROW( exc, msg ) throw exc{ error{ __FILE__, __LINE__, __FUNCTION__, msg } }
 #else
-#define C2XA_THROW( exc, msg ) throw
+#define C2XA_THROW( exc, msg ) throw exc{}
 #endif
 
 #endif//C2XA_EXCEPTION_HPP

--- a/Classes/c2xa/observer.hpp
+++ b/Classes/c2xa/observer.hpp
@@ -1,0 +1,155 @@
+﻿
+
+/**
+
+    @file   observer.hpp
+    @brief  observer
+
+    @author 新ゝ月かりな(NewNotMoon)
+    @date   created on 2016/00/00
+
+*/
+#pragma once
+#ifndef C2XA_OBSERVER_HPP
+#define C2XA_OBSERVER_HPP
+
+#include <list>
+
+#include <cocos2d.h>
+
+#include <c2xa/utility.hpp>
+
+namespace c2xa
+{
+    template< typename DATA >
+    class subject;
+    template< typename DATA >
+    class observer
+        : public cocos2d::Node
+    {
+    private:
+        subject<DATA>* bind_ = nullptr;
+        std::function<void( DATA )> callback_;
+
+    public:
+        static observer<DATA>* create( std::function<void( DATA )> c )
+        {
+            return create_template<observer<DATA>>( c );
+        }
+        virtual bool init( std::function<void( DATA )> c )
+        {
+            using namespace cocos2d;
+            if( !Node::init() )
+            {
+                return false;
+            }
+            callback_ = c;
+            return true;
+        }
+        ~observer();
+        void notified( DATA a )
+        {
+            callback_( a );
+        }
+        void bind( subject<DATA>* a, bool pre_registry_ = false );
+        void cancel();
+    };
+    template< typename DATA >
+    class subject_interface
+    {
+    public:
+        using observer_type = observer<DATA>;
+
+    public:
+        virtual void registry_observer( observer_type* o, bool pre_bind_ = false ) = 0;
+        virtual void remove_observer( observer_type* o, bool pre_separate_ = false ) = 0;
+    };
+    template< typename DATA >
+    class subject
+        : public subject_interface< DATA >
+    {
+    public:
+        using observer_type  = observer<DATA>;
+        using interface_type = subject_interface<DATA>;
+
+    private:
+        std::list<observer_type*> observers_;
+
+    public:
+        ~subject()
+        {
+            clear();
+        }
+        void notify( DATA data_ )
+        {
+            for( auto i : observers_ )
+            {
+                i->notified( data_ );
+            }
+        }
+        void registry_observer( observer_type* o, bool pre_bind_ = false ) override
+        {
+            if( !pre_bind_ )
+            {
+                o->bind( this, false );
+            }
+            observers_.push_back( o );
+        }
+        void remove_observer( observer_type* o, bool pre_separate_ = false ) override
+        {
+            observers_.erase( std::remove_if( observers_.begin(), observers_.end(),
+                [ o, pre_separate_ ]( observer_type* i )
+            {
+                if( o == i )
+                {
+                    if( !pre_separate_ )
+                    {
+                        i->cancel();
+                    }
+                    return true;
+                }
+                return false;
+            } ), observers_.end() );
+        }
+        void clear()
+        {
+            for( auto i : observers_ )
+            {
+                i->cancel();
+            }
+            observers_.clear();
+        }
+    };
+    template< typename DATA >
+    void bind_observer( subject< DATA >* sub_, observer< DATA >* obs_ )
+    {
+        obs_->bind( sub_ );
+        sub_->registry_observer( obs_ );
+    }
+    template< typename DATA >
+    observer<DATA>::~observer()
+    {
+        cancel();
+    }
+    template< typename DATA >
+    void observer<DATA>::bind( subject<DATA>* a, bool pre_registry_ )
+    {
+        cancel();
+        bind_ = a;
+        if( !pre_registry_ )
+        {
+            bind_->registry_observer( this, true );
+        }
+    }
+    template< typename DATA >
+    void observer<DATA>::cancel()
+    {
+        if( bind_ )
+        {
+            bind_->remove_observer( this, true );
+            bind_ = nullptr;
+        }
+    }
+}
+
+#endif//C2XA_OBSERVER_HPP

--- a/Classes/c2xa/scene/main_scene.cpp
+++ b/Classes/c2xa/scene/main_scene.cpp
@@ -20,7 +20,6 @@ try
 }
 catch( c2xa::bluetooth_exception& e )
 {
-    cocos2d::log( e.error_.message.c_str() );
     throw e;
 }
 

--- a/Classes/c2xa/scene/title_scene.cpp
+++ b/Classes/c2xa/scene/title_scene.cpp
@@ -117,35 +117,36 @@ bool title_scene::init()
         auto text_2p = static_cast<cocos2d::Label*>( getChildByName( "text_2p_condition" ) );
         switch( state_ )
         {
-        case connection_state::connect:
-        {
-            text_2p->setString( "2P: CONNECT" );
-            text_2p->setOpacity( 0 );
-            text_2p->runAction( FadeTo::create( 0.3f, 255 ) );
+            case connection_state::connect:
+            {
+                text_2p->setString( "2P: CONNECT" );
+                text_2p->setOpacity( 0 );
+                text_2p->runAction( FadeTo::create( 0.3f, 255 ) );
 
-            auto particle_ = ParticleSystemQuad::create( "particle/entry.plist" );
-            particle_->setAnchorPoint( Vec2::ANCHOR_TOP_LEFT );
-            particle_->setPosition( condition_2p_particle_ );
-            particle_->setAutoRemoveOnFinish( true );
-            addChild( particle_, 12 );
+                auto particle_ = ParticleSystemQuad::create( "particle/entry.plist" );
+                particle_->setAnchorPoint( Vec2::ANCHOR_TOP_LEFT );
+                particle_->setPosition( condition_2p_particle_ );
+                particle_->setAutoRemoveOnFinish( true );
+                addChild( particle_, 12 );
 
-            break;
-        }
-        case connection_state::disconnect:
-        {
-            text_2p->setString( "2P: DISCONNECT" );
-            break;
-        }
-        case connection_state::reconnect:
-        {
-            text_2p->setString( "2P: CONNECT" );
-            break;
-        }
+                break;
+            }
+            case connection_state::disconnect:
+            {
+                text_2p->setString( "2P: DISCONNECT" );
+                break;
+            }
+            case connection_state::reconnect:
+            {
+                text_2p->setString( "2P: CONNECT" );
+                break;
+            }
         }
     } );
     addChild( observer_2p );
 
     auto com_ = communication_node::create();
+    com_->setName( "com_node" );
     com_->get_subject_1p()->registry_observer( observer_1p );
     com_->get_subject_2p()->registry_observer( observer_2p );
     addChild( com_ );
@@ -155,5 +156,13 @@ bool title_scene::init()
 
 void title_scene::update( float )
 {
+    using namespace cocos2d;
 
+    auto com_node_ = static_cast<communication_node*>( getChildByName( "com_node" ) );
+    com_node_->receive_1p( []( auto buffer_ )
+    {
+    } );
+    com_node_->receive_2p( []( auto buffer_ )
+    {
+    } );
 }

--- a/Classes/c2xa/scene/title_scene.cpp
+++ b/Classes/c2xa/scene/title_scene.cpp
@@ -12,6 +12,7 @@
 #include <c2xa/config.hpp>
 #include <c2xa/exception.hpp>
 #include <c2xa/scene/title_scene.hpp>
+#include <c2xa/communication/node.hpp>
 
 using namespace c2xa::scene;
 
@@ -78,137 +79,81 @@ bool title_scene::init()
     text_2p_->setName( "text_2p_condition" );
     addChild( text_2p_, 11 );
 
-    listener_ = std::make_shared<bluetooth::listener>();
-    address_1p = 0;
-    address_2p = 0;
+    auto observer_1p = observer<connection_state>::create( [ this ]( connection_state state_ )
+    {
+        auto text_1p = static_cast<cocos2d::Label*>( getChildByName( "text_1p_condition" ) );
+        switch( state_ )
+        {
+        case connection_state::connect:
+        {
+            text_1p->setString( "1P: CONNECT" );
+            text_1p->setOpacity( 0 );
+            text_1p->runAction( FadeTo::create( 0.3f, 255 ) );
+
+            auto particle_ = ParticleSystemQuad::create( "particle/entry.plist" );
+            particle_->setAnchorPoint( Vec2::ANCHOR_TOP_LEFT );
+            particle_->setPosition( condition_1p_particle_ );
+            particle_->setAutoRemoveOnFinish( true );
+            addChild( particle_, 12 );
+
+            break;
+        }
+        case connection_state::disconnect:
+        {
+            text_1p->setString( "1P: DISCONNECT" );
+            break;
+        }
+        case connection_state::reconnect:
+        {
+            text_1p->setString( "1P: CONNECT" );
+            break;
+        }
+        }
+    } );
+    addChild( observer_1p );
+
+    auto observer_2p = observer<connection_state>::create( [ this ]( connection_state state_ )
+    {
+        auto text_2p = static_cast<cocos2d::Label*>( getChildByName( "text_2p_condition" ) );
+        switch( state_ )
+        {
+        case connection_state::connect:
+        {
+            text_2p->setString( "2P: CONNECT" );
+            text_2p->setOpacity( 0 );
+            text_2p->runAction( FadeTo::create( 0.3f, 255 ) );
+
+            auto particle_ = ParticleSystemQuad::create( "particle/entry.plist" );
+            particle_->setAnchorPoint( Vec2::ANCHOR_TOP_LEFT );
+            particle_->setPosition( condition_2p_particle_ );
+            particle_->setAutoRemoveOnFinish( true );
+            addChild( particle_, 12 );
+
+            break;
+        }
+        case connection_state::disconnect:
+        {
+            text_2p->setString( "2P: DISCONNECT" );
+            break;
+        }
+        case connection_state::reconnect:
+        {
+            text_2p->setString( "2P: CONNECT" );
+            break;
+        }
+        }
+    } );
+    addChild( observer_2p );
+
+    auto com_ = communication_node::create();
+    com_->get_subject_1p()->registry_observer( observer_1p );
+    com_->get_subject_2p()->registry_observer( observer_2p );
+    addChild( com_ );
 
     return true;
 }
 
 void title_scene::update( float )
 {
-    using namespace cocos2d;
 
-    auto text_message_ = static_cast<cocos2d::Label*>( getChildByName( "text_message" ) );
-    auto text_1p = static_cast<cocos2d::Label*>( getChildByName( "text_1p_condition" ) );
-    auto text_2p = static_cast<cocos2d::Label*>( getChildByName( "text_2p_condition" ) );
-
-    if( listener_ )
-    {
-        auto accepted_ = listener_->accept();
-        if( accepted_ )
-        {
-            do
-            {
-                if( !connection_1p )
-                {
-                    if( address_1p == 0 )
-                    {
-                        // 初接続
-                        connection_1p = std::move( *accepted_ );
-                        address_1p = connection_1p->get_client_address();
-                        text_1p->setString( "1P: CONNECT" );
-                        text_1p->setOpacity( 0 );
-                        text_1p->runAction( FadeTo::create( 0.3f, 255 ) );
-
-                        auto particle_ = ParticleSystemQuad::create( "particle/entry.plist" );
-                        particle_->setAnchorPoint( Vec2::ANCHOR_TOP_LEFT );
-                        particle_->setPosition( condition_1p_particle_ );
-                        particle_->setAutoRemoveOnFinish( true );
-                        addChild( particle_, 12 );
-
-                        break;
-                    }
-                    else if( address_1p == ( *accepted_ )->get_client_address() )
-                    {
-                        // 1p 再接続
-                        connection_1p = std::move( *accepted_ );
-                        text_1p->setString( "1P: CONNECT" );
-                        break;
-                    }
-                }
-                if( !connection_2p )
-                {
-                    if( address_2p == 0 )
-                    {
-                        // 初接続
-                        connection_2p = std::move( *accepted_ );
-                        address_2p = connection_2p->get_client_address();
-                        text_2p->setString( "2P: CONNECT" );
-
-                        auto particle_ = ParticleSystemQuad::create( "particle/entry.plist" );
-                        particle_->setAnchorPoint( Vec2::ANCHOR_TOP_LEFT );
-                        particle_->setPosition( condition_2p_particle_ );
-                        particle_->setAutoRemoveOnFinish( true );
-                        addChild( particle_, 12 );
-
-                        break;
-                    }
-                    else if( address_2p == ( *accepted_ )->get_client_address() )
-                    {
-                        // 2p 再接続
-                        connection_2p = std::move( *accepted_ );
-                        text_2p->setString( "2P: CONNECT" );
-                        break;
-                    }
-                }
-            }
-            while( false );
-            if( connection_1p && connection_2p )
-            {
-                listener_.reset();
-            }
-        }
-    }
-
-    if( connection_1p )
-    {
-        auto receive = [ this ]()
-        {
-            std::memset( buffer_, '\0', sizeof( buffer_ ) );
-            return connection_1p->receive( buffer_, sizeof( buffer_ ), 0 );
-        };
-        try
-        {
-            auto state_ = receive();
-            while( state_ == bluetooth::connection::socket_state::success )
-            {
-                state_ = receive();
-            }
-        }
-        catch( bluetooth_disconnect_exception const& e )
-        {
-            connection_1p.reset();
-            text_1p->setString( "1P: DISCONNECT" );
-            if( !listener_ )
-            {
-                listener_ = std::make_shared<bluetooth::listener>();
-            }
-        }
-    }
-    if( connection_2p )
-    {
-        auto receive = [ this ]
-        {
-            std::memset( buffer_, '\0', sizeof( buffer_ ) );
-            return connection_2p->receive( buffer_, sizeof( buffer_ ), 0 );
-        };
-        try
-        {
-            auto state_ = receive();
-            while( state_ == bluetooth::connection::socket_state::success )
-            {
-                state_ = receive();
-            }
-        }
-        catch( bluetooth_disconnect_exception const& e )
-        {
-            connection_2p.reset();
-            text_2p->setString( "2P: DISCONNECT" );
-            if( !listener_ )
-            {
-                listener_ = std::make_shared<bluetooth::listener>();
-            }
-        }
-    }
 }

--- a/Classes/c2xa/scene/title_scene.hpp
+++ b/Classes/c2xa/scene/title_scene.hpp
@@ -15,8 +15,6 @@
 
 #include <cocos2d.h>
 
-#include <c2xa/communication/bluetooth/server.hpp>
-
 namespace c2xa
 {
     namespace scene
@@ -24,14 +22,6 @@ namespace c2xa
         class title_scene
             : public cocos2d::Scene
         {
-        private:
-            char buffer_[ 2048 ];
-            std::shared_ptr<bluetooth::listener> listener_;
-            std::shared_ptr<bluetooth::connection> connection_1p;
-            std::shared_ptr<bluetooth::connection> connection_2p;
-            BTH_ADDR address_1p;
-            BTH_ADDR address_2p;
-
         public:
             CREATE_FUNC( title_scene );
             virtual bool init() override;

--- a/Classes/c2xa/utility.hpp
+++ b/Classes/c2xa/utility.hpp
@@ -1,0 +1,41 @@
+﻿
+
+/**
+
+    @file   utility.hpp
+    @brief  utility
+
+    @author 新ゝ月かりな(NewNotMoon)
+    @date   created on 2016/00/00
+
+*/
+#pragma once
+#ifndef C2XA_UTILITY_HPP
+#define C2XA_UTILITY_HPP
+
+namespace c2xa
+{
+
+    /*!
+        Cocos2d-xのCREATE_FUNCの代わりとなるヘルパ関数です。
+        init関数が複数の引数を保つ場合でも使えます。
+    */
+    template< typename TYPE, typename... ARGS >
+    inline TYPE* create_template( ARGS&&... a )
+    {
+        auto p = new TYPE{};
+
+        if( p && p->init( std::forward<ARGS>( a )... ) )
+        {
+            p->autorelease();
+            return p;
+        }
+        else
+        {
+            delete p;
+            return nullptr;
+        }
+    };
+}
+
+#endif//C2XA_UTILITY_HPP

--- a/proj.win32/ABC2016SpringServer.vcxproj
+++ b/proj.win32/ABC2016SpringServer.vcxproj
@@ -146,6 +146,10 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
   <ItemGroup>
     <ClCompile Include="..\Classes\app_delegate.cpp" />
     <ClCompile Include="..\Classes\c2xa\communication\bluetooth\server.cpp" />
+    <ClCompile Include="..\Classes\c2xa\communication\node.cpp">
+      <SubType>
+      </SubType>
+    </ClCompile>
     <ClCompile Include="..\Classes\c2xa\communication\windows_socket_api.cpp">
       <SubType>
       </SubType>
@@ -173,6 +177,10 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
   <ItemGroup>
     <ClInclude Include="..\Classes\app_delegate.hpp" />
     <ClInclude Include="..\Classes\c2xa\communication\bluetooth\server.hpp" />
+    <ClInclude Include="..\Classes\c2xa\communication\node.hpp">
+      <SubType>
+      </SubType>
+    </ClInclude>
     <ClInclude Include="..\Classes\c2xa\communication\windows_socket_api.hpp">
       <SubType>
       </SubType>
@@ -203,6 +211,10 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
       <SubType>
       </SubType>
     </ClInclude>
+    <ClInclude Include="..\Classes\c2xa\observer.hpp">
+      <SubType>
+      </SubType>
+    </ClInclude>
     <ClInclude Include="..\Classes\c2xa\optional.hpp">
       <SubType>
       </SubType>
@@ -224,6 +236,10 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
       </SubType>
     </ClInclude>
     <ClInclude Include="..\Classes\c2xa\scene\title_scene.hpp">
+      <SubType>
+      </SubType>
+    </ClInclude>
+    <ClInclude Include="..\Classes\c2xa\utility.hpp">
       <SubType>
       </SubType>
     </ClInclude>

--- a/proj.win32/ABC2016SpringServer.vcxproj.filters
+++ b/proj.win32/ABC2016SpringServer.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="..\Classes\c2xa\communication\bluetooth\server.cpp">
       <Filter>src\c2xa\communication\bluetooth</Filter>
     </ClCompile>
+    <ClCompile Include="..\Classes\c2xa\communication\node.cpp">
+      <Filter>src\c2xa\communication</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="main.h">
@@ -118,6 +121,15 @@
     </ClInclude>
     <ClInclude Include="..\Classes\c2xa\communication\bluetooth\server.hpp">
       <Filter>src\c2xa\communication\bluetooth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\c2xa\communication\node.hpp">
+      <Filter>src\c2xa\communication</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\c2xa\utility.hpp">
+      <Filter>src\c2xa</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\c2xa\observer.hpp">
+      <Filter>src\c2xa</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
通信モジュールを分離、ノード化。
それに伴って各シーンからのイベントキャッチがオブザーバ形式になります。(以下タイトルシーンから引用)

``` cpp
    auto observer_2p = observer<connection_state>::create( [ this ]( connection_state state_ )
    {
        auto text_2p = static_cast<cocos2d::Label*>( getChildByName( "text_2p_condition" ) );
        switch( state_ )
        {
            case connection_state::connect:
            {
                text_2p->setString( "2P: CONNECT" );
                text_2p->setOpacity( 0 );
                text_2p->runAction( FadeTo::create( 0.3f, 255 ) );

                auto particle_ = ParticleSystemQuad::create( "particle/entry.plist" );
                particle_->setAnchorPoint( Vec2::ANCHOR_TOP_LEFT );
                particle_->setPosition( condition_2p_particle_ );
                particle_->setAutoRemoveOnFinish( true );
                addChild( particle_, 12 );

                break;
            }
            case connection_state::disconnect:
            {
                text_2p->setString( "2P: DISCONNECT" );
                break;
            }
            case connection_state::reconnect:
            {
                text_2p->setString( "2P: CONNECT" );
                break;
            }
        }
    } );
    addChild( observer_2p );

    auto com_ = communication_node::create();
    com_->setName( "com_node" );
    com_->get_subject_1p()->registry_observer( observer_1p );
```

これは通信確立と切断を監視するだけで、受信するか否かは別コードになります。

受信部分は関数オブジェクトを渡す形になります。キューが溜まってると複数回関数オブジェクトが使用されます。
